### PR TITLE
Bugfix: `scales` in `TonedScale` trying to call property `_scales`

### DIFF
--- a/pytheory/scales.py
+++ b/pytheory/scales.py
@@ -108,7 +108,7 @@ class TonedScale:
 
     @property
     def scales(self):
-        return tuple(self._scales().keys())
+        return tuple(self._scales.keys())
 
     @property
     def _scales(self):


### PR DESCRIPTION
Bug was causing TypeError exception when trying to access the property `scales` of a `TonedScale` object.