### PR TITLE
bugfix: TonedScale wasn't working for tonics in octave 0

### DIFF
--- a/pytheory/tones.py
+++ b/pytheory/tones.py
@@ -34,7 +34,7 @@ class Tone:
 
     @property
     def full_name(self):
-        if self.octave:
+        if self.octave is not None:
             return f"{self.name}{self.octave}"
         else:
             return self.name
@@ -65,7 +65,7 @@ class Tone:
         except ValueError:
             octave = None
 
-        tone = s.replace(str(octave), '') if octave else s
+        tone = s.replace(str(octave), '') if octave is not None else s
 
         if system:
             return klass(name=tone, octave=octave, system=system)


### PR DESCRIPTION
Trying to use `TonedScale` with a tonic in octave 0 was rasing `ValueError`.
This was working correctly before 629ce151431b1ba78f10feeab176eee031f192a8

```python
>>> a0 = TonedScale(tonic="A0")
>>> a0.scales

File "/home/diego/Projects/_libraries_src/pytheory/pytheory/tones.py", line 92, in _index
    return self.system.tones.index(self.name)
ValueError: tuple.index(x): x not in tuple
```
This PR fix it.