### PR TITLE
Fix dict is not callable in TonedScale.scales

### DIFF
--- a/pytheory/charts.py
+++ b/pytheory/charts.py
@@ -68,7 +68,7 @@ class NamedChord:
 
     @property
     def acceptable_tone_names(self):
-        return tuple([tone.name for tone in self.acceptable_tones])
+        return tuple((tone.name for tone in self.acceptable_tones))
 
     def _possible_fingerings(self, *, fretboard):
         def find_fingerings(tone):
@@ -129,11 +129,11 @@ class NamedChord:
                 if fingering_score(possible_fingering) == max_score:
                     yield possible_fingering
 
-        best_fingerings = tuple([g for g in gen()])
+        best_fingerings = tuple(g for g in gen())
         if not multiple:
             return self.fix_fingering(best_fingerings[0])
         else:
-            return tuple([self.fix_fingering(f) for f in best_fingerings])
+            return tuple((self.fix_fingering(f) for f in best_fingerings))
 
 
 

--- a/pytheory/chords.py
+++ b/pytheory/chords.py
@@ -3,7 +3,7 @@ class Chord:
         self.tones = tones
 
     def __repr__(self):
-        l = tuple([tone.full_name for tone in self.tones])
+        l = tuple((tone.full_name for tone in self.tones))
         return f"<Chord tones={l!r}>"
 
     # @property
@@ -20,7 +20,7 @@ class Fretboard:
         self.tones = tones
 
     def __repr__(self):
-        l = tuple([tone.full_name for tone in self.tones])
+        l = tuple((tone.full_name for tone in self.tones))
         return f"<Fretboard tones={l!r}>"
 
     def fingering(self, *positions):

--- a/pytheory/scales.py
+++ b/pytheory/scales.py
@@ -108,7 +108,7 @@ class TonedScale:
 
     @property
     def scales(self):
-        return tuple(self._scales().keys())
+        return tuple(self._scales.keys())
 
     @property
     def _scales(self):

--- a/pytheory/systems.py
+++ b/pytheory/systems.py
@@ -18,7 +18,7 @@ class System:
     @property
     def tones(self):
         from . import Tone
-        return tuple([Tone.from_tuple(tone) for tone in self.tone_names])
+        return tuple((Tone.from_tuple(tone) for tone in self.tone_names))
 
 
     @property


### PR DESCRIPTION
- Fix `dict is not callable` in `TonedScale.scales`
- Swap list comprehensions to generator expressions

Closes https://github.com/kennethreitz/pytheory/issues/17