### PR TITLE
Make custom drum patterns a first-class public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to PyTheory are documented here.
 
+## Unreleased
+
+- **Custom drum patterns are now first-class.** `Hit` is a public,
+  top-level export (`from pytheory import Hit`) — no more reaching for
+  the private `pytheory.rhythm._Hit` to build a pattern. The old name
+  stays as an alias for back-compat.
+- **`score.drums()` accepts a `Pattern` object**, not just a preset
+  name string — so a groove you built yourself gets the same
+  `repeats`, `fill`, `split`, and `layer` options as the built-ins.
+- **`layer=True` on `score.drums()` / `score.add_pattern()`** overlays
+  a pattern on top of the existing drums instead of appending it in
+  sequence — the supported way to stack grooves and polyrhythms,
+  replacing the `_drum_pattern_beats` cursor hack. (#52, #55, #56)
+
 ## 0.50.0
 
 - **Real-time chord recognition — `pytheory tune --chords`.** Strum

--- a/docs/guide/drums.rst
+++ b/docs/guide/drums.rst
@@ -687,12 +687,41 @@ Strings match the :class:`DrumSound` member names, case-insensitive:
 ``"kick"``, ``"snare"``, ``"closed_hat"``, ``"ride_bell"``,
 ``"conga_high"``, and so on — all 74 sounds.
 
-Mixing Preset Patterns
-----------------------
+Reusable Custom Patterns
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To package a groove you can repeat, reuse, or export, build a
+:class:`Pattern` from a list of :class:`Hit` objects. Each :class:`Hit`
+names a sound, its position in beats (``0.0`` is beat 1, ``0.5`` the
+following eighth, ``0.25`` a sixteenth), and an optional velocity for
+ghost notes:
+
+.. code-block:: python
+
+   from pytheory import Score, Pattern, Hit, DrumSound
+
+   K, S, CH = DrumSound.KICK, DrumSound.SNARE, DrumSound.CLOSED_HAT
+
+   beat = Pattern("my beat", [
+       Hit(K, 0.0),  Hit(CH, 0.0),  Hit(CH, 0.5),
+       Hit(S, 1.0),  Hit(CH, 1.0),  Hit(CH, 1.5),
+       Hit(K, 2.0),  Hit(CH, 2.0),  Hit(K, 2.5),  Hit(CH, 2.5),
+       Hit(S, 3.0),  Hit(CH, 3.0),  Hit(S, 1.75, velocity=35),  # ghost
+   ], beats=4.0)
+
+   score = Score("4/4", bpm=120, drum_humanize=0.15)
+   score.drums(beat, repeats=4)
+
+``score.drums()`` accepts a :class:`Pattern` object anywhere it accepts
+a preset name, so your own grooves get the same ``repeats``, ``fill``,
+``split``, and ``layer`` options as the built-ins.
+
+Mixing and Layering Patterns
+----------------------------
 
 ``score.add_pattern()`` is the lower-level cousin of ``score.drums()``
-— it takes a :class:`Pattern` object instead of a preset name, so you
-can chain different grooves back to back:
+— it takes a :class:`Pattern` object, so you can chain different grooves
+back to back:
 
 .. code-block:: python
 
@@ -701,6 +730,33 @@ can chain different grooves back to back:
    score.add_pattern(Pattern.preset("rock"), repeats=3)
    score.add_pattern(Pattern.fill("rock"), repeats=1)
    score.add_pattern(Pattern.preset("half time"), repeats=4)
+
+By default each call lands *after* the previous one, so they play in
+sequence. To stack grooves so they sound at the same time — a clave
+over a backbeat, or a polyrhythm — pass ``layer=True``. The layered
+pattern is laid down from the start, in parallel with what's already
+there:
+
+.. code-block:: python
+
+   score = Score("4/4", bpm=120)
+   score.drums("rock", repeats=4)
+   score.drums("son clave 3-2", repeats=4, layer=True)   # on top, not after
+
+For a true polyrhythm, put both voices in one pattern at their
+fractional positions — three evenly-spaced congas against four kicks
+across the same four beats:
+
+.. code-block:: python
+
+   from pytheory import Pattern, Hit, DrumSound
+
+   three = [Hit(DrumSound.CONGA_HIGH, i * 4 / 3) for i in range(3)]
+   four  = [Hit(DrumSound.KICK,       i * 1.0)   for i in range(4)]
+   poly  = Pattern("3-against-4", three + four, beats=4.0)
+
+   score = Score("4/4", bpm=120)
+   score.add_pattern(poly, repeats=4)
 
 MIDI Export
 -----------

--- a/pytheory/__init__.py
+++ b/pytheory/__init__.py
@@ -8,7 +8,7 @@ from .scales import TonedScale, Key, PROGRESSIONS
 from .chords import Chord, Fretboard, analyze_progression
 from .charts import CHARTS, Fingering, charts_for_fretboard
 
-from .rhythm import Duration, TimeSignature, Rest, Score, Part, Section, DrumSound, Pattern, INSTRUMENTS
+from .rhythm import Duration, TimeSignature, Rest, Score, Part, Section, DrumSound, Pattern, Hit, INSTRUMENTS
 from .rhythm import Note as RhythmNote  # rhythm.Note (tone + duration pairing)
 
 from .play import (play, save, save_midi, play_progression, play_pattern,
@@ -25,5 +25,5 @@ __all__ = [
     "play", "save", "save_midi", "play_progression", "play_pattern",
     "play_score", "render_score", "Synth", "Envelope",
     "Duration", "TimeSignature", "RhythmNote", "Rest", "Score", "Part",
-    "DrumSound", "Pattern", "Section", "INSTRUMENTS",
+    "DrumSound", "Pattern", "Hit", "Section", "INSTRUMENTS",
 ]

--- a/pytheory/rhythm.py
+++ b/pytheory/rhythm.py
@@ -732,8 +732,21 @@ class _DrumTone:
         return -self.sound.value
 
 
-class _Hit:
-    """A single drum hit at a specific position in a pattern."""
+class Hit:
+    """A single drum hit at a specific position in a pattern.
+
+    Args:
+        sound: A :class:`DrumSound` (e.g. ``DrumSound.KICK``).
+        position: Position within the pattern, in beats. ``0.0`` is beat 1,
+            ``0.5`` the following eighth, ``0.25`` a sixteenth, and so on.
+        velocity: MIDI velocity, 1–127. Lower values make ghost notes.
+
+    Example::
+
+        >>> from pytheory import Hit, DrumSound, Pattern
+        >>> beat = Pattern("my beat", [Hit(DrumSound.KICK, 0.0),
+        ...                            Hit(DrumSound.SNARE, 2.0)])
+    """
     __slots__ = ("sound", "position", "velocity")
 
     def __init__(self, sound: DrumSound, position: float, velocity: int = 100):
@@ -743,6 +756,10 @@ class _Hit:
 
     def __repr__(self):
         return f"Hit({self.sound.name}, beat={self.position}, vel={self.velocity})"
+
+
+# Back-compat alias — ``_Hit`` was the original (private) name.
+_Hit = Hit
 
 
 class Pattern:
@@ -759,7 +776,7 @@ class Pattern:
         <Pattern 'rock' 4/4 4.0 beats 12 hits>
     """
 
-    def __init__(self, name: str, hits: list[_Hit], beats: float = 4.0,
+    def __init__(self, name: str, hits: list[Hit], beats: float = 4.0,
                  time_signature: str = "4/4"):
         self.name = name
         self.hits = hits
@@ -4263,22 +4280,32 @@ class Score:
         """
         return sorted(INSTRUMENTS.keys())
 
-    def add_pattern(self, pattern, repeats: int = 1) -> "Score":
+    def add_pattern(self, pattern, repeats: int = 1,
+                    layer: bool = False) -> "Score":
         """Add a drum pattern to this score.
+
+        By default each call is placed *after* the previously added drums, so
+        successive calls play in sequence. Pass ``layer=True`` to overlay this
+        pattern on top of what's already there (starting from the beginning),
+        which is how you stack grooves for polyrhythms.
 
         Args:
             pattern: A :class:`Pattern` object.
             repeats: Number of times to repeat.
+            layer: If True, overlay starting at beat 0 instead of appending,
+                and leave the running position unchanged.
 
         Returns:
             Self for chaining.
         """
+        base = 0.0 if layer else self._drum_pattern_beats
         for r in range(repeats):
-            offset = self._drum_pattern_beats + r * pattern.beats
+            offset = base + r * pattern.beats
             for hit in pattern.hits:
                 self._drum_hits.append(
-                    _Hit(hit.sound, hit.position + offset, hit.velocity))
-        self._drum_pattern_beats += repeats * pattern.beats
+                    Hit(hit.sound, hit.position + offset, hit.velocity))
+        if not layer:
+            self._drum_pattern_beats += repeats * pattern.beats
         return self
 
     def fill(self, name: str = "rock") -> "Score":
@@ -4304,18 +4331,23 @@ class Score:
                        DrumSound.GUIRO.value, DrumSound.MARACAS.value},
     }
 
-    def drums(self, preset: str, repeats: int = 4, fill: str = None,
-              fill_every: int = None, split: bool = False) -> "Score":
-        """Add a drum pattern by preset name, with optional auto-fills.
+    def drums(self, preset, repeats: int = 4, fill: str = None,
+              fill_every: int = None, split: bool = False,
+              layer: bool = False) -> "Score":
+        """Add a drum pattern, with optional auto-fills.
 
         Args:
-            preset: Pattern preset name (e.g. ``"bossa nova"``, ``"rock"``).
+            preset: A pattern preset name (e.g. ``"bossa nova"``, ``"rock"``)
+                or a :class:`Pattern` object you built yourself.
             repeats: Number of times to repeat (default 4).
-            fill: Optional fill name.
+            fill: Optional fill name (preset names only).
             fill_every: Replace every Nth bar with a fill.
             split: If True, create separate Parts for kick, snare, hats,
                 toms, cymbals, and percussion — each with independent
                 effects. Access via ``score.parts["kick"]``, etc.
+            layer: If True, overlay these drums on top of what's already
+                there (starting at the beginning) instead of appending them
+                in sequence — use this to stack grooves for polyrhythms.
 
         Returns:
             Self for chaining.
@@ -4325,11 +4357,21 @@ class Score:
             >>> score.drums("rock", repeats=4, split=True)
             >>> score.parts["snare"].reverb_mix = 0.3
             >>> score.parts["hats"].lowpass = 6000
+
+            >>> # Layer a clave on top of the rock beat
+            >>> score.drums("son clave 3-2", repeats=4, layer=True)
         """
+        groove = preset if isinstance(preset, Pattern) else Pattern.preset(preset)
+
+        # To layer, lay these drums down from the start in parallel with what's
+        # already there, then restore the playhead so later calls aren't moved.
+        saved = self._drum_pattern_beats
+        if layer:
+            self._drum_pattern_beats = 0.0
+
         if fill is None:
-            self.add_pattern(Pattern.preset(preset), repeats=repeats)
+            self.add_pattern(groove, repeats=repeats)
         else:
-            groove = Pattern.preset(preset)
             fill_pattern = Pattern.fill(fill)
             if fill_every is None:
                 fill_every = repeats
@@ -4338,6 +4380,9 @@ class Score:
                     self.add_pattern(fill_pattern, repeats=1)
                 else:
                     self.add_pattern(groove, repeats=1)
+
+        if layer:
+            self._drum_pattern_beats = max(saved, self._drum_pattern_beats)
 
         if split:
             self._split_drums()

--- a/test_pytheory.py
+++ b/test_pytheory.py
@@ -5303,6 +5303,55 @@ def test_score_add_pattern_chaining():
     assert result is score
 
 
+def test_hit_public_export_and_alias():
+    from pytheory import Hit, DrumSound
+    from pytheory.rhythm import _Hit
+    assert Hit is _Hit  # back-compat alias
+    h = Hit(DrumSound.KICK, 1.5, velocity=80)
+    assert h.sound is DrumSound.KICK
+    assert h.position == 1.5
+    assert h.velocity == 80
+
+
+def test_pattern_from_public_hits():
+    from pytheory import Pattern, Hit, DrumSound
+    beat = Pattern("custom", [Hit(DrumSound.KICK, 0.0),
+                              Hit(DrumSound.SNARE, 2.0)])
+    assert len(beat.hits) == 2
+    assert beat.beats == 4.0
+
+
+def test_drums_accepts_pattern_object():
+    from pytheory import Score, Pattern, Hit, DrumSound
+    beat = Pattern("custom", [Hit(DrumSound.KICK, 0.0),
+                              Hit(DrumSound.SNARE, 2.0)])
+    score = Score("4/4", bpm=120)
+    score.drums(beat, repeats=2)
+    assert len(score._drum_hits) == 4
+    assert score._drum_pattern_beats == 8.0
+
+
+def test_add_pattern_layer_overlays():
+    from pytheory import Score, Pattern
+    score = Score("4/4", bpm=120)
+    score.add_pattern(Pattern.preset("rock"), repeats=1)  # beats 0..3.5
+    score.add_pattern(Pattern.preset("rock"), repeats=1, layer=True)
+    # Layered copy overlays from beat 0, so nothing lands past the first bar.
+    assert max(h.position for h in score._drum_hits) < 4.0
+    # ...and the running playhead is left untouched.
+    assert score._drum_pattern_beats == 4.0
+
+
+def test_drums_layer_keeps_cursor_at_furthest_extent():
+    from pytheory import Score
+    score = Score("4/4", bpm=120)
+    score.drums("rock", repeats=2)            # 8 beats
+    score.drums("rock", repeats=1, layer=True)  # overlaid, shorter
+    assert score._drum_pattern_beats == 8.0   # unchanged — shorter overlay
+    score.drums("rock", repeats=1)            # sequential add resumes after 8
+    assert max(h.position for h in score._drum_hits) >= 8.0
+
+
 def test_part_repr():
     from pytheory import Score, Duration
     score = Score("4/4", bpm=120)


### PR DESCRIPTION
Closes the ergonomics gap behind #52 and #55, tracked in #56.

## What

1. **`Hit` is public** — top-level `from pytheory import Hit`, with `_Hit` kept as a back-compat alias. Building a custom `Pattern` no longer needs a private import.
2. **`score.drums()` accepts a `Pattern`** — pass a groove you built yourself anywhere a preset name works, and get the same `repeats`/`fill`/`split`/`layer` options.
3. **`layer=True`** on `drums()` / `add_pattern()` overlays a pattern on top of the existing drums instead of appending it in sequence — the supported way to stack grooves and polyrhythms, replacing the `_drum_pattern_beats = 0` cursor hack.

## Notes

- `drums(layer=True)` saves/restores the playhead around the call so multi-bar layered fills still sequence their bars, and advances the cursor only to the furthest extent so later sequential adds don't collide. `add_pattern(layer=True)` is the lower-level primitive (overlays from beat 0, leaves the cursor untouched).
- Deliberately did *not* add `Pattern.from_hits()` / `Pattern.hit()` — making `Hit` public covers the need with less surface area. Easy to add if preferred.

## Tests & docs

- 5 new tests (public/alias identity, building from public `Hit`s, `drums(Pattern)`, both layering semantics). Full suite: 956 passed.
- `docs/guide/drums.rst`: "Reusable Custom Patterns" + rewritten "Mixing and Layering Patterns" with clave-overlay and 3-against-4 polyrhythm examples.
- `CHANGELOG.md`: Unreleased entry.

Refs #52, #55, #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
