### PR TITLE
feat: Score.ring_out() for effect tails + web SessionStart hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# SessionStart hook: install system + Python deps so the audio test suite
+# runs in Claude Code on the web. pytheory depends on `sounddevice`, whose
+# Linux wheels don't bundle PortAudio — without libportaudio2 the package
+# fails to import and ~every test errors with "PortAudio library not found".
+set -euo pipefail
+
+# Only needed in the remote (web) environment.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# System library for sounddevice (mirrors the CI workflow's install step).
+if ! ldconfig -p 2>/dev/null | grep -q 'libportaudio\.so\.2'; then
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq libportaudio2
+fi
+
+# Python dependencies (cached after first run; `sync` is incremental).
+cd "$CLAUDE_PROJECT_DIR"
+uv sync

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to PyTheory are documented here.
 
+## Unreleased
+
+- **`Score.ring_out()` — let reverb/delay tails breathe.** Rendering used
+  to stop dead on the final beat, clipping the tail of any reverb or delay
+  on the last hit (especially noticeable on drum tracks with a long
+  reverb). Call `score.ring_out()` once before playing or exporting and it
+  appends trailing silence sized automatically to the longest effect tail
+  across all parts — pass an explicit `seconds` to override. Opt-in, so
+  seamless loops are unaffected. (Resolves #60.)
+
 ## 0.53.1
 
 - **More ragas, and reverb on playback.** The raga set grows from 20 to

--- a/pytheory/play.py
+++ b/pytheory/play.py
@@ -5027,6 +5027,59 @@ def _apply_delay(samples, mix=0.25, time=0.375, feedback=0.4,
     return samples * (1 - mix) + wet * mix
 
 
+# Reverb tail length (seconds) for each convolution IR preset. Must mirror
+# the ``duration`` values in _generate_ir(); used to size ring-out silence.
+_IR_DURATIONS = {
+    "taj_mahal": 12.0,
+    "cathedral": 6.0,
+    "plate": 4.0,
+    "spring": 3.0,
+    "cave": 8.0,
+    "parking_garage": 3.0,
+    "canyon": 5.0,
+}
+
+
+def effects_tail_seconds(part) -> float:
+    """Estimate how long a part's reverb/delay tail keeps ringing.
+
+    Used by :meth:`Score.ring_out` to auto-size the trailing silence so
+    effect tails decay naturally instead of being clipped at the last beat.
+
+    Args:
+        part: A :class:`~pytheory.rhythm.Part` (or anything exposing the
+            reverb_mix / delay_mix effect attributes).
+
+    Returns:
+        Tail length in seconds (0.0 if the part has no time-based effects).
+    """
+    tail = 0.0
+
+    # Reverb: convolution presets have a fixed IR length; the algorithmic
+    # reverb rings for roughly its decay time.
+    if getattr(part, "reverb_mix", 0.0) > 0:
+        rev_type = getattr(part, "reverb_type", "algorithmic")
+        if rev_type in _IR_DURATIONS:
+            tail += _IR_DURATIONS[rev_type]
+        else:
+            tail += getattr(part, "reverb_decay", 1.0)
+
+    # Delay: echoes repeat until they fall below the audible floor, capped
+    # at the same 8 taps _apply_delay() generates.
+    if getattr(part, "delay_mix", 0.0) > 0:
+        delay_time = getattr(part, "delay_time", 0.375)
+        feedback = getattr(part, "delay_feedback", 0.4)
+        echoes, gain = 0, 1.0
+        for _ in range(8):
+            gain *= feedback
+            if gain < 0.01:
+                break
+            echoes += 1
+        tail += delay_time * (echoes + 1)
+
+    return tail
+
+
 def _apply_lowpass(samples, cutoff, q=0.707, sample_rate=SAMPLE_RATE):
     """Apply a 2nd-order Butterworth lowpass filter (12 dB/octave).
 

--- a/pytheory/rhythm.py
+++ b/pytheory/rhythm.py
@@ -4048,6 +4048,10 @@ class Score:
         self._tempo_changes: list[tuple[float, int]] = []
         self._sections: dict[str, Section] = {}
         self._current_section: Optional[Section] = None
+        # Trailing silence (in beats) appended after all content so reverb
+        # and delay tails can ring out instead of being cut off. Set via
+        # ring_out().
+        self._tail_beats: float = 0.0
 
     def _ensure_drums_part(self) -> Part:
         """Get or create the drums Part."""
@@ -4103,6 +4107,45 @@ class Score:
             for k, v in kwargs.items():
                 attr = param_map.get(k, k)
                 setattr(p, attr, v)
+        return self
+
+    def ring_out(self, seconds: float = None) -> "Score":
+        """Append trailing silence so reverb/delay tails ring out fully.
+
+        Without this, the rendered audio stops exactly at the last beat,
+        which clips the tail of any reverb or delay on the final hit. Call
+        ``ring_out()`` once (typically just before playing or exporting) to
+        pad the end with enough silence for the effects to decay naturally.
+
+        Args:
+            seconds: Length of trailing silence in seconds. When omitted,
+                it's computed automatically from the longest reverb/delay
+                tail across all parts (including drums). Pass an explicit
+                value to override.
+
+        Returns:
+            Self for chaining.
+
+        Example::
+
+            score.set_drum_effects(reverb=0.4, reverb_type="cave",
+                                   delay=0.3, delay_time=0.25)
+            score.drums("funk", repeats=8)
+            score.ring_out()          # auto-sized tail
+            play_score(score)
+
+        Note:
+            The added silence makes the score longer, so avoid calling this
+            on a pattern you intend to loop seamlessly.
+        """
+        if seconds is None:
+            from .play import effects_tail_seconds
+            seconds = max(
+                (effects_tail_seconds(p) for p in self.parts.values()),
+                default=0.0,
+            )
+        beats = seconds * self.bpm / 60.0
+        self._tail_beats = max(self._tail_beats, beats)
         return self
 
     def part(self, name: str, *, instrument: str = None,
@@ -4522,7 +4565,9 @@ class Score:
         beats = [sum(n.beats for n in self.notes), self._drum_pattern_beats]
         for p in self.parts.values():
             beats.append(p.total_beats)
-        return max(beats) if beats else 0.0
+        content = max(beats) if beats else 0.0
+        # Trailing silence (ring_out) is appended *after* the content.
+        return content + self._tail_beats
 
     @property
     def measures(self) -> float:

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -235,6 +235,51 @@ def test_part_effects_change_output():
 
 
 @needs_portaudio
+def test_ring_out_appends_tail_for_effects():
+    from pytheory import Score
+    from pytheory.play import render_score, effects_tail_seconds
+
+    score = Score("4/4", bpm=120)
+    score.drums("funk", repeats=4)
+    score.set_drum_effects(reverb=0.5, reverb_type="cave",
+                           delay=0.3, delay_time=0.25, delay_feedback=0.4)
+    before = render_score(score)
+
+    # ring_out() appends auto-sized trailing silence; the render grows.
+    assert score.ring_out() is score          # chainable
+    after = render_score(score)
+    assert len(after) > len(before)
+
+    # The appended region carries the reverb/delay tail (not pure silence).
+    tail = after[len(before):]
+    assert numpy.sqrt(numpy.mean(tail ** 2)) > 1e-4
+
+    # Auto length matches the computed effects tail (cave reverb + delay).
+    drum_part = next(p for p in score.parts.values() if p.is_drums)
+    tail_beats = effects_tail_seconds(drum_part) * score.bpm / 60.0
+    assert score.total_beats == pytest.approx(16.0 + tail_beats)
+
+
+@needs_portaudio
+def test_ring_out_is_opt_in_and_explicit():
+    from pytheory import Score
+    from pytheory.play import render_score
+
+    # No effects + no explicit length => no tail added.
+    plain = Score("4/4", bpm=120)
+    plain.drums("rock", repeats=2)
+    assert plain.ring_out().total_beats == 4.0 * 2
+
+    # Explicit seconds override the auto-sizing.
+    score = Score("4/4", bpm=120)
+    score.drums("rock", repeats=2)
+    score.ring_out(2.0)
+    # 2.0s at 120bpm = 4 extra beats appended after the 8-beat groove.
+    assert score.total_beats == pytest.approx(8.0 + 4.0)
+    assert len(render_score(score)) > 0
+
+
+@needs_portaudio
 def test_chorus_effect():
     from pytheory.play import _apply_chorus
     t = numpy.arange(44100, dtype=numpy.float32) / 44100


### PR DESCRIPTION
Two quick wins:

- Score.ring_out([seconds]) appends trailing silence so reverb/delay
  tails ring out instead of being clipped at the last beat (resolves
  #60). Length auto-sizes to the longest effect tail across all parts
  (new play.effects_tail_seconds helper + _IR_DURATIONS table); pass an
  explicit duration to override. Opt-in via a new Score._tail_beats that
  total_beats adds after content, so seamless loops are unaffected.

- .claude SessionStart hook installs libportaudio2 + runs `uv sync` so
  the audio test suite works in Claude Code on the web (sounddevice's
  Linux wheels don't bundle PortAudio; without it the package fails to
  import and nearly every test errors).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014ijpMiuST8kXnBoB5pSu8t